### PR TITLE
Support Linux device stats that may be larger than a signed int can hold

### DIFF
--- a/netstat.go
+++ b/netstat.go
@@ -10,14 +10,14 @@ import (
 type NetworkStats []NetworkStat
 
 type networkInfo struct {
-	Bytes      int64 `json:"bytes"`
-	Packets    int64 `json:"packets"`
-	Drop       int64 `json:"drop"`
-	Errs       int64 `json:"errs"`
-	Fifo       int64 `json:"fifo"`
-	Frame      int64 `json:"frame"`
-	Compressed int64 `json:"compressed"`
-	Multicast  int64 `json:"multicast"`
+	Bytes      uint64 `json:"bytes"`
+	Packets    uint64 `json:"packets"`
+	Drop       uint64 `json:"drop"`
+	Errs       uint64 `json:"errs"`
+	Fifo       uint64 `json:"fifo"`
+	Frame      uint64 `json:"frame"`
+	Compressed uint64 `json:"compressed"`
+	Multicast  uint64 `json:"multicast"`
 }
 
 type NetworkStat struct {
@@ -76,8 +76,8 @@ func toNetworkInfo(fields []string) networkInfo {
 	}
 }
 
-func toInt(str string) int64 {
-	res, err := strconv.ParseInt(str, 10, 64)
+func toInt(str string) uint64 {
+	res, err := strconv.ParseUint(str, 10, 64)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Linux writes interface stats to /proc/net/dev as unsigned 64 bit integers, so parsing them as signed 64 bits will cause a panic once any value exceeds the max signed value (9223372036854775807). It's a big number, but systems get there eventually. Parsing as unsigned will handle anything Linux outputs there.

Relevant Linux source: http://elixir.free-electrons.com/linux/v4.9.47/source/include/uapi/linux/if_link.h#L43